### PR TITLE
[2-single-view-metrology] Corrected y-intercept typo

### DIFF
--- a/02-single-view-metrology/02-single-view-metrology.tex
+++ b/02-single-view-metrology/02-single-view-metrology.tex
@@ -58,7 +58,7 @@ Despite not preserving parallelism, projective transformations does preserve col
 We leave proving the invariance of the cross ratio under projective transformation as a class exercise.
 
 \section{Points and Lines at Infinity}
-Lines are important for determining structure in images, so knowing their definitions in both 2D and 3D is essential. A line in 2D can be represented with the homogenous vector $\ell = \begin{bmatrix}a & b & c \end{bmatrix}^T$. The ratio $-\frac{a}{b}$ captures the slope of the line and the ratio $-\frac{b}{c}$ captures the y-intercept. Formally, 2D lines are defined by:
+Lines are important for determining structure in images, so knowing their definitions in both 2D and 3D is essential. A line in 2D can be represented with the homogenous vector $\ell = \begin{bmatrix}a & b & c \end{bmatrix}^T$. The ratio $-\frac{a}{b}$ captures the slope of the line and the ratio $-\frac{c}{b}$ captures the y-intercept. Formally, 2D lines are defined by:
 \begin{equation}
 \forall p = \begin{bmatrix}x\\y\end{bmatrix} \in \ell,\ \  \begin{bmatrix}a & b & c\end{bmatrix}\begin{bmatrix}x\\y\\1\end{bmatrix} = 0
 \end{equation}


### PR DESCRIPTION
I think it should be -c/b.

Consider [a b c] * [x y 1] = 0. Then ax + by + c = 0 => by = -ax - c => y = -ax/b - c/b.